### PR TITLE
CR- Hexagon Support (multiple states)

### DIFF
--- a/WME-Road-Shields-Helper.user.js
+++ b/WME-Road-Shields-Helper.user.js
@@ -241,6 +241,7 @@
         console.log(streetname)
         let regex = /(?:(CH|H|I|M|CH|WIS|(?:[A-Z]\w)(?=\-))-((?:[A-Z]\w)|(?:\d+(?:[A-Z])?(?:-\d+)?)))?(?: (BUS|ALT|BYP|CONN|SPUR|TRUCK))?(?: (N|E|S|W))?/;
         let SRStates = ['Alabama', 'Arizona', 'Illinois', 'New Hampshire', 'Pennsylvania', 'Washington'];
+        let CRHex = ['Alabama', 'Arkansas', 'Louisiana', 'Florida', 'New Jersey', 'New York'];
         let match = streetname.match(regex);
 
         console.log(match)
@@ -315,6 +316,14 @@
             case "CH":
                 if (State == "Wisconsin") {
                     MakeShield(match,State,"County");
+                }
+                break;
+            case "CR":
+                if (CRHex.indexOf(State)>=0) {
+                    console.log(match[1]);
+                    document.querySelector(`#wz-dialog-container > div > wz-dialog > wz-dialog-content > div:nth-child(1) > wz-menu > [title="CR generic Main"]`).click()
+                } else {
+                    CreateAlert(`Warning: CR design for this state has not been defined. <br>Consult local guidance and <a target="_blank" href="https://github.com/TheCre8r/WME-Road-Shields-Filter/issues/new" id="WMERSH-report-an-issue">${I18n.t(`wmersh.report_an_issue`)}</a>`);
                 }
                 break;
             case "H":

--- a/WME-Road-Shields-Helper.user.js
+++ b/WME-Road-Shields-Helper.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Road Shield Helper
 // @namespace    https://github.com/thecre8r/
-// @version      2021.06.02.01
+// @version      2021.06.03.01
 // @description  Observes for the modal
 // @include      https://www.waze.com/editor*
 // @include      https://www.waze.com/*/editor*
@@ -26,7 +26,7 @@
     const SCRIPT_NAME = GM_info.script.name;
     const SCRIPT_VERSION = GM_info.script.version.toString();
     //{"version": "2021.06.01.02","changes": ""},
-    const SCRIPT_HISTORY = `{"versions": [{"version": "2021.06.02.01","changes": "Added SR Shield for New Hampshire"},{"version": "2021.06.01.02","changes": "Added County Shields for Wisconsin<br>Updated Changelog Format"},{"version": "2021.06.01.01","changes": "Fixed GitHub URL"},{"version": "2021.05.31.01","changes": "Added Wisconsin and other miscellaneous fixes"},{"version": "2021.05.23.01","changes": "Initial Version"}]}`;
+    const SCRIPT_HISTORY = `{"versions": [{"version": "2021.06.03.01","changes": "Added CR support for states using hexagon type shields"},{"version": "2021.06.02.01","changes": "Added SR Shield for New Hampshire"},{"version": "2021.06.01.02","changes": "Added County Shields for Wisconsin<br>Updated Changelog Format"},{"version": "2021.06.01.01","changes": "Fixed GitHub URL"},{"version": "2021.05.31.01","changes": "Added Wisconsin and other miscellaneous fixes"},{"version": "2021.05.23.01","changes": "Initial Version"}]}`;
     const GH = {link: 'https://github.com/TheCre8r/WME-Road-Shield-Helper/', issue: 'https://github.com/TheCre8r/WME-Road-Shield-Helper/issues/new', wiki: 'https://github.com/TheCre8r/WME-Road-Shield-Helper/wiki'};
     const UPDATE_ALERT = true;
 
@@ -137,7 +137,7 @@
         log("Tab Initialized");
     }
 
-    let TESTERS = ["The_Cre8r","jm6087","s18slider","locojd1","SethSpeedy28","nzahn1","doctorkb"];
+    let TESTERS = ["The_Cre8r","jm6087","s18slider","locojd1","SethSpeedy28","nzahn1","doctorkb","turnertr"];
 
     function setChecked(checkboxId, checked) {
         $('#WMERSH-' + checkboxId).prop('checked', checked);
@@ -241,7 +241,7 @@
         console.log(streetname)
         let regex = /(?:(CH|H|I|M|CH|WIS|(?:[A-Z]\w)(?=\-))-((?:[A-Z]\w)|(?:\d+(?:[A-Z])?(?:-\d+)?)))?(?: (BUS|ALT|BYP|CONN|SPUR|TRUCK))?(?: (N|E|S|W))?/;
         let SRStates = ['Alabama', 'Arizona', 'Illinois', 'New Hampshire', 'Pennsylvania', 'Washington'];
-        let CRHex = ['Alabama', 'Arkansas', 'Louisiana', 'Florida', 'New Jersey', 'New York'];
+        let CRHex = ['Alabama', 'Arkansas', 'Florida', 'Louisiana', 'New Jersey', 'New York'];
         let match = streetname.match(regex);
 
         console.log(match)
@@ -313,17 +313,17 @@
         let State = getState()
         let DoneStates = ["North Carolina"].concat(SRStates);
         switch (match[1] ) {
-            case "CH":
-                if (State == "Wisconsin") {
-                    MakeShield(match,State,"County");
-                }
-                break;
             case "CR":
                 if (CRHex.indexOf(State)>=0) {
                     console.log(match[1]);
                     document.querySelector(`#wz-dialog-container > div > wz-dialog > wz-dialog-content > div:nth-child(1) > wz-menu > [title="CR generic Main"]`).click()
                 } else {
-                    CreateAlert(`Warning: CR design for this state has not been defined. <br>Consult local guidance and <a target="_blank" href="https://github.com/TheCre8r/WME-Road-Shields-Filter/issues/new" id="WMERSH-report-an-issue">${I18n.t(`wmersh.report_an_issue`)}</a>`);
+                    CreateAlert(`Warning: CR design for this state has not been defined. <br>Consult local guidance and <a target="_blank" href="${GH.issue}" id="WMERSH-report-an-issue">${I18n.t(`wmersh.report_an_issue`)}</a>`);
+                }
+                break;
+            case "CH":
+                if (State == "Wisconsin") {
+                    MakeShield(match,State,"County");
                 }
                 break;
             case "H":


### PR DESCRIPTION
Add logic for standard hexagon type county road shields.  
A variable is created CRHex for states that utilize county road shields, and is verified under the CR- match.
(I don't claim to know every state that uses Hexagons, but I did input the ones I knew off of the top of my head.)

--
turnertr