### PR TITLE
Missouri SH-xx Shield Support

### DIFF
--- a/WME-Road-Shields-Helper.user.js
+++ b/WME-Road-Shields-Helper.user.js
@@ -239,7 +239,7 @@
 
         let streetname = document.querySelector("#wz-dialog-container > div > wz-dialog > wz-dialog-header > div.street-name").innerText
         console.log(streetname)
-        let regex = /(?:(CH|H|I|M|CH|WIS|(?:[A-Z]\w)(?=\-))-((?:[A-Z]\w)|(?:\d+(?:[A-Z])?(?:-\d+)?)))?(?: (BUS|ALT|BYP|CONN|SPUR|TRUCK))?(?: (N|E|S|W))?/;
+        let regex = /(?:(CH|H|I|M|CH|WIS|(?:[A-Z]\w)(?=\-))-((?:[A-Z]\w?)|(?:\d+(?:[A-Z])?(?:-\d+)?)))?(?: (BUS|ALT|BYP|CONN|SPUR|TRUCK))?(?: (N|E|S|W))?/;
         let SRStates = ['Alabama', 'Arizona', 'Illinois', 'New Hampshire', 'Pennsylvania', 'Washington'];
         let CRHex = ['Alabama', 'Arkansas', 'Florida', 'Louisiana', 'New Jersey', 'New York'];
         let match = streetname.match(regex);
@@ -351,7 +351,9 @@
                 }
                 break;
             case "SH":
-                if (State == "Texas") {
+                if (State == "Missouri" && match[3] == undefined) {
+                    document.querySelector(`#wz-dialog-container > div > wz-dialog > wz-dialog-content > div:nth-child(1) > wz-menu > [title="Missouri - State Supplemental"]`).click()
+                } else if (State == "Texas") {
                     MakeShield(match,State);
                 }
                 break;


### PR DESCRIPTION
#8 Support for Missouri SH-xx shield format. Required single character modification of regex to allow matching of single letter routes (e.g. SH-K).