### PR TITLE
IA/KS/MN/TN Shield Updates

### DIFF
--- a/WME-Road-Shields-Helper.user.js
+++ b/WME-Road-Shields-Helper.user.js
@@ -296,7 +296,7 @@ function startScriptUpdateMonitor() {
         let regex = /(?:((?:(?:[A-Z]+)(?=\-))|(?:Beltway)|(?:Loop)|(?:TOLL)|(?:Parish Rd)|(?:Park Rd)|(?:Recreational Rd)|(?:Spur))(?:-|\ )((?:[A-Z]+)|(?:\d+(?:[A-Z])?(?:-\d+)?)))?(?: (ALT-TRUCK|BUS|ALT|BYP|CONN|SPUR|TRUCK|TOLL|Toll|LOOP|NASA|Park|LINK))?(?: (N|E|S|W))?(?: • (.*))?/;
         let SHStates = ['Colorado', 'Minnesota', 'Oklahoma', 'Texas'];
         let SRStates = ['Alabama', 'Arizona', 'California', 'Connecticut', 'Florida', 'Georgia', 'Illinois', 'Massachusetts', 'Maine', 'New Hampshire', 'New Mexico', 'Ohio', 'Pennsylvania', 'Utah', 'Washington'];
-        let CRStates = ['Alabama', 'Arkansas', 'Florida', 'Louisiana', 'Kansas', 'New Jersey', 'New York', 'North Dakota', 'South Dakota', 'Tennessee'];
+        let CRStates = ['Alabama', 'Arkansas', 'Florida', 'Louisiana', 'Iowa', 'Kansas', 'New Jersey', 'New York', 'North Dakota', 'South Dakota', 'Tennessee'];
         let DoneStates = ['Delaware', 'North Carolina', 'New Jersey', 'Tennessee', 'Virginia'].concat(SRStates);
         let match = streetname.match(regex);
 

--- a/WME-Road-Shields-Helper.user.js
+++ b/WME-Road-Shields-Helper.user.js
@@ -414,6 +414,8 @@ function startScriptUpdateMonitor() {
                     document.querySelector(`#wz-dialog-container > div > wz-dialog > wz-dialog-content > div:nth-child(1) > wz-menu > [title="CR generic Main"]`).click()
                 } else if (State == "Illinois") {
                     CreateError(`Warning: Illinois does not use CR shields for CRs.`,`Error`);
+                } else if (State == "Minnesota") {
+                    document.querySelector(`#wz-dialog-container > div > wz-dialog > wz-dialog-content > div:nth-child(1) > wz-menu > [title="Minnesota -County Road"]`).click()                    
                 } else if (State == "West Virginia" & !streetname.includes("/")) {
                     MakeShield(match,State, "County" ,"Main");
                 } else {

--- a/WME-Road-Shields-Helper.user.js
+++ b/WME-Road-Shields-Helper.user.js
@@ -297,7 +297,7 @@ function startScriptUpdateMonitor() {
         let SHStates = ['Colorado', 'Minnesota', 'Oklahoma', 'Texas'];
         let SRStates = ['Alabama', 'Arizona', 'California', 'Connecticut', 'Florida', 'Georgia', 'Illinois', 'Massachusetts', 'Maine', 'New Hampshire', 'New Mexico', 'Ohio', 'Pennsylvania', 'Utah', 'Washington'];
         let CRStates = ['Alabama', 'Arkansas', 'Florida', 'Louisiana', 'Kansas', 'New Jersey', 'New York', 'North Dakota', 'South Dakota', 'Tennessee'];
-        let DoneStates = ['Delaware', 'North Carolina', 'New Jersey', 'Virginia'].concat(SRStates);
+        let DoneStates = ['Delaware', 'North Carolina', 'New Jersey', 'Tennessee', 'Virginia'].concat(SRStates);
         let match = streetname.match(regex);
 
         if (document.querySelector("#WMERSH-Message")) {
@@ -530,6 +530,8 @@ function startScriptUpdateMonitor() {
                     MakeShield(match,State);
                 } else if (State == "North Carolina") {
                     CreateError(`Error: ${State} does not use road shields for Secondary Routes`,`Error`);
+                } else if (State == "Tennessee") {
+                    MakeShield(match,State,undefined,"Secondary");
                 } else if (State == "Virginia") {
                     if (match[2] < 600 || match[2] == 785 || match[2] == 895) {
                         MakeShield(match,State);

--- a/WME-Road-Shields-Helper.user.js
+++ b/WME-Road-Shields-Helper.user.js
@@ -296,7 +296,7 @@ function startScriptUpdateMonitor() {
         let regex = /(?:((?:(?:[A-Z]+)(?=\-))|(?:Beltway)|(?:Loop)|(?:TOLL)|(?:Parish Rd)|(?:Park Rd)|(?:Recreational Rd)|(?:Spur))(?:-|\ )((?:[A-Z]+)|(?:\d+(?:[A-Z])?(?:-\d+)?)))?(?: (ALT-TRUCK|BUS|ALT|BYP|CONN|SPUR|TRUCK|TOLL|Toll|LOOP|NASA|Park|LINK))?(?: (N|E|S|W))?(?: • (.*))?/;
         let SHStates = ['Colorado', 'Minnesota', 'Oklahoma', 'Texas'];
         let SRStates = ['Alabama', 'Arizona', 'California', 'Connecticut', 'Florida', 'Georgia', 'Illinois', 'Massachusetts', 'Maine', 'New Hampshire', 'New Mexico', 'Ohio', 'Pennsylvania', 'Utah', 'Washington'];
-        let CRStates = ['Alabama', 'Arkansas', 'Florida', 'Louisiana', 'New Jersey', 'New York', 'North Dakota', 'South Dakota', 'Tennessee'];
+        let CRStates = ['Alabama', 'Arkansas', 'Florida', 'Louisiana', 'Kansas', 'New Jersey', 'New York', 'North Dakota', 'South Dakota', 'Tennessee'];
         let DoneStates = ['Delaware', 'North Carolina', 'New Jersey', 'Virginia'].concat(SRStates);
         let match = streetname.match(regex);
 


### PR DESCRIPTION
- Approves IA, KS to use standard CR Shields: Closes Issues #52, #61, #67 
- Adds support for MN Specialized County Shields: Closes Issue #69 
- Adds support for TN Secondary State Highways (SR-): Closes Issue #57 